### PR TITLE
Make strategy work and return info.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,33 @@
 PATH
   remote: .
   specs:
-    omniauth-basecamp (0.1.0)
+    omniauth-basecamp (0.2.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    faraday (0.9.0)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    hashie (3.3.1)
-    jwt (1.0.0)
-    multi_json (1.10.1)
-    multi_xml (0.5.5)
+    hashie (3.5.6)
+    jwt (1.5.6)
+    multi_json (1.12.2)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    omniauth (1.2.2)
-      hashie (>= 1.2, < 4)
-      rack (~> 1.0)
-    omniauth-oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
-      multi_json (~> 1.3)
+      rack (>= 1.2, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    rack (1.5.2)
+    rack (2.0.3)
     rake (10.3.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -51,3 +49,6 @@ DEPENDENCIES
   omniauth-basecamp!
   rake
   rspec
+
+BUNDLED WITH
+   1.16.0.pre.2

--- a/lib/omniauth/strategies/basecamp.rb
+++ b/lib/omniauth/strategies/basecamp.rb
@@ -3,11 +3,10 @@ require 'omniauth/strategies/oauth2'
 module OmniAuth
   module Strategies
     class Basecamp < OmniAuth::Strategies::OAuth2
-      option :client_options, {
-        :site => 'https://launchpad.37signals.com',
-        :authorize_url => '/authorization/new',
-        :token_url => '/authorization/token'
-      }
+      option :client_options,
+             site: 'https://launchpad.37signals.com',
+             authorize_url: '/authorization/new',
+             token_url: '/authorization/token'
 
       def authorize_params
         super.tap do |params|
@@ -18,19 +17,35 @@ module OmniAuth
         end
       end
 
-      def request_phase
-        super
+      uid do
+        info[:id]
+      end
+
+      info do
+        raw_info.fetch(:identity)
+      end
+
+      extra do
+        raw_info
       end
 
       def build_access_token
         token_params = {
-          :code => request.params['code'],
-          :redirect_uri => callback_url,
-          :client_id => client.id,
-          :client_secret => client.secret,
-          :type => 'web_server'
+          code: request.params['code'],
+          redirect_uri: callback_url,
+          client_id: client.id,
+          client_secret: client.secret,
+          type: 'web_server'
         }
         client.get_token(token_params)
+      end
+
+      def raw_info
+        @raw_info ||= deep_symbolize(access_token.get('/authorization.json').parsed)
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
     end
   end

--- a/spec/omniauth/strategies/basecamp_spec.rb
+++ b/spec/omniauth/strategies/basecamp_spec.rb
@@ -20,6 +20,44 @@ describe OmniAuth::Strategies::Basecamp do
     end
   end
 
+  describe '#raw_info' do
+    it 'requests raw info' do
+      @access_token = double('OAuth2::AccessToken')
+      subject.stub(:access_token) { @access_token }
+      response = double('response', parsed: {"key" => "value"})
+      @access_token.should_receive(:get).with('/authorization.json').and_return(response)
+
+      subject.raw_info.should eq(key: "value")
+    end
+  end
+
+  describe '#info' do
+    it 'returns info' do
+      identity = {id: 1234, email_address: 'john@example.com'}
+      subject.stub(:raw_info).and_return(identity: identity)
+
+      subject.info.should eq(identity)
+    end
+  end
+
+  describe '#uid' do
+    it 'returns info' do
+      info = {id: 1234}
+      subject.stub(:info).and_return(info)
+
+      subject.uid.should eq(1234)
+    end
+  end
+
+  describe '#extra' do
+    it 'returns raw info' do
+      raw_info = {raw_info: true}
+      subject.stub(:raw_info).and_return(raw_info)
+
+      subject.extra.should eq(raw_info)
+    end
+  end
+
   describe '#client' do
     it 'has correct authorize url' do
       subject.client.options[:authorize_url].should eq('/authorization/new')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,11 @@ require 'rspec'
 Dir[File.expand_path('../support/**/*', __FILE__)].each { |f| require f }
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :should
+  end
+
+  config.mock_with :rspec do |c|
+    c.syntax = :should
+  end
 end


### PR DESCRIPTION
This PR makes omniauth-basecamp work with current API (v3). It also returns some info (previously there was no uid and info nodes).